### PR TITLE
Topic: Entity Annotator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,4 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+	python -m spacy download en_core_web_sm

--- a/Makefile
+++ b/Makefile
@@ -90,4 +90,3 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
-	python -m spacy download en_core_web_sm

--- a/cdptools/dev_utils/load_custom_object.py
+++ b/cdptools/dev_utils/load_custom_object.py
@@ -61,7 +61,7 @@ def load_custom_object_from_config(custom_object_label: str, config: Dict):
     obj: object
         The initialized object.
     """
-    return load_custom_object.load_custom_object(
+    return load_custom_object(
         module_path=config[custom_object_label]["module_path"],
         object_name=config[custom_object_label]["object_name"],
         object_kwargs=config[custom_object_label].get("object_kwargs", {})

--- a/cdptools/natural_language_analyzers/__init__.py
+++ b/cdptools/natural_language_analyzers/__init__.py
@@ -3,5 +3,4 @@
 """Natural language analyzers package for cdptools."""
 
 
-from .nl_analyzer import NLAnalyzer # noqa: F401
-from .entity_analyzer import EntityAnalyzer # noqa: F401
+from .natural_language_analyzer import NLAnalyzer, EntityAnalyzer # noqa: F401

--- a/cdptools/natural_language_analyzers/__init__.py
+++ b/cdptools/natural_language_analyzers/__init__.py
@@ -3,4 +3,5 @@
 """Natural language analyzers package for cdptools."""
 
 
-from .natural_language_analyzer import NLAnalyzer, EntityAnalyzer  # noqa: F401
+from .nl_analyzer import NLAnalyzer # noqa: F401
+from .entity_analyzer import EntityAnalyzer # noqa: F401

--- a/cdptools/natural_language_analyzers/__init__.py
+++ b/cdptools/natural_language_analyzers/__init__.py
@@ -3,4 +3,5 @@
 """Natural language analyzers package for cdptools."""
 
 
-from .natural_language_analyzer import NLAnalyzer, EntityAnalyzer # noqa: F401
+from .nl_analyzer import NLAnalyzer # noqa: F401
+from .entity_analyzer import EntityAnalyzer # noqa: F401

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -1,14 +1,306 @@
-from .nl_analyzer import NLAnalyzer
+from datetime import datetime as dt
+from itertools import chain, groupby
+
+from typing import Any, Callable, List, Union
+from mypy_extensions import TypedDict
+import dateutil.parser as parser
+import en_core_web_sm
+import spacy
+from spacy import displacy
+
+from nl_analyzer import NLAnalyzer
+
+AnnotationValueTypes = Union[int, float, str, dt]
+Annotation = TypedDict(
+    "Annotation",
+    {"start": int, "end": int, "label": str, "value": AnnotationValueTypes},
+)
+"""
+    Given a list of spacy entities, the source spacy Doc, and a datetime, produce a list of annotations.
+"""
+EntityAnnotator = Callable[[List[spacy.tokens.Span], spacy.tokens.Doc, dt], List[Annotation]]
+
+
+def _annotate_as_label(label):
+    """
+        Creates an annotator that returns the entity annotation as-is with the given annotation label.
+
+        Parameters
+        ----------
+        label: str
+            The label to apply to the generated annotations
+
+        Returns
+        -------
+        annotator: EntityAnnotator
+            An entity annotator which applies the given label
+    """
+
+    def annotate(entities, doc, event_time):
+        """
+            Produces annotations consisting of the exact source spacy entity text
+            with the given custom annotation label
+
+            Parameters
+            ----------
+            entities: spacy.tokens.Span
+                A list of spacy.tokens.Span objects representing entities
+            doc: spacy.tokens.Doc
+                The spacy doc the entities are derived from
+            event_time: datetime
+                The timestamp that the event occurred on
+
+            Returns
+            -------
+            annotations
+                A list of annotations with the given label
+        """
+        return [span_to_annotate(e, label, e.text) for e in entities]
+
+    return annotate
+
+
+def _annotate_empty(entities, doc, event_time):
+    """
+        An Annotator which produces no annotations for the given entities.
+
+        Parameters
+        ----------
+        entities: List[spacy.tokens.Span]
+            A list of spacy.tokens.Span objects representing entities
+        doc: spacy.tokens.Doc
+            The spacy doc the entities are derived from
+        event_time: datetime
+            The timestamp that the event occurred on
+
+        Returns
+        -------
+        annotations
+            An empty list.
+    """
+    return []
+
+
+def _annotate_person_entities(entities, doc, event):
+    """
+        Produce annotations for person entities.
+
+        This filters out entities for ones containing spaces, using that as a proxy
+        to indicate first and last name.
+
+        Parameters
+        ----------
+        entities: List[spacy.tokens.Span]
+            A list of spacy.tokens.Span objects representing entities
+        doc: spacy.tokens.Doc
+            The spacy doc the entities are derived from
+        event_time: datetime
+            The timestamp that the event occurred on
+
+        Returns
+        -------
+        annotations
+            A list of absolute date annotations.
+    """
+    filtered = [span_to_annotation(e, "Entity[Person]", e.text) for e in entities if ' ' in e.text]
+    return filtered
+
+def _annotate_date_entities(entities, doc, event_time):
+    """
+        Parse exact dates and transform relative dates into exact dates based on date and
+        time the event ocurred.
+
+        Parameters
+        ----------
+        entities: List[spacy.tokens.Span]
+            A list of spacy.tokens.Span objects representing entities
+        doc: spacy.tokens.Doc
+            The spacy doc the entities are derived from
+        event_time: datetime
+            The timestamp that the event occurred on
+
+        Returns
+        -------
+        annotations
+            A list of absolute date annotations.
+    """
+    base_date = event_time
+    transcribed_dates = []
+    for e in entities:
+        try:
+            parsed_date = parser.parse(e.text)
+            transcribed_dates.append(
+                _span_to_annotation(e, "Entity[Date]", parsed_date)
+            )
+        except ValueError:
+            pass
+    return transcribed_dates
+
+
+def _annotate_product_entities(entities, doc, event_time):
+    """
+        Produces annotations of product names, removing commong false positives.
+
+        False positives removed:
+            - "amendment"
+
+        Parameters
+        ----------
+        entities: List[spacy.tokens.Span]
+            A list of spacy.tokens.Span objects representing entities
+        doc: spacy.tokens.Doc
+            The spacy doc the entities are derived from
+        event_time: datetime
+            The timestamp that the event occurred on
+
+        Returns
+        -------
+        annotations
+            A list of product entity annotations
+    """
+    filtered = [e for e in entities if e.text.lower() != "amendment"]
+    return [_span_to_annotation(e, "Entity[Product]", e.text) for e in filtered]
+
+
+def _annotate_money_entities(entities, doc, event_time):
+    """
+        Produces annotations of monetary values.
+
+        Ideally, we'd like to do some additional analysis here to associate those
+        dollar amounts back to some expenditure, budget, etc.
+
+        Parameters
+        ----------
+        entities: List[spacy.tokens.Span]
+            A list of spacy.tokens.Span objects representing entities
+        doc: spacy.tokens.Doc
+            The spacy doc the entities are derived from
+        event_time: datetime
+            The timestamp that the event occurred on
+
+        Returns
+        -------
+        annotations
+            A list of monetary annotations.
+    """
+    return [_span_to_annotation(e, "Entity[Money]", e.text) for e in entities]
+
+
+def _span_to_annotation(span, label, value):
+    """
+        Convert a Spacy span to an annotation with the given label and value.
+
+        Parameters
+        ----------
+        span: spacy.tokens.Span
+            The source span for the annotation
+        label: str
+            A string label to apply to the annotation
+        value: AnnotationValueType
+            The timestamp that the event occurred on
+
+        Returns
+        -------
+        annotations
+            A list of monetary annotations.
+    """
+    return {"start": span.start, "end": span.end, "label": label, "value": value}
 
 
 class EntityAnalyzer(NLAnalyzer):
+    def __init__(self):
+        self.NLP = en_core_web_sm.load()
+        self._entity_annotators_by_type = {
+            "PERSON": _annotate_person_entities,
+            "CARDINAL": _annotate_empty,
+            "DATE": _annotate_date_entities,
+            "ORG": _annotate_as_label("Entity[Organization]"),
+            "GPE": _annotate_as_label("Entity[GPE]"),
+            "ORDINAL": _annotate_empty,
+            "FAC": _annotate_as_label("Entity[FAC]"),
+            "LOC": _annotate_as_label("Entity[Location]"),
+            "TIME": _annotate_empty,
+            "NORP": _annotate_as_label("Entity[NORP]"),
+            "QUANTITY": _annotate_empty,
+            "PRODUCT": _annotate_product_entities,
+            "MONEY": _annotate_money_entities,
+            "PERCENT": _annotate_empty,
+            "LAW": _annotate_as_label("Entity[Law]"),
+            "EVENT": _annotate_as_label("Entity[Event]"),
+            "WORK_OF_ART": _annotate_as_label("Entity[WorkOfArt]"),
+            "LANGUAGE": _annotate_empty,
+        }
+
+    @staticmethod
+    def _create_doc(text, nlp_model):
+        """
+        Given a spacy NLP model, analyze text, returning a spacy doc.
+        """
+        return nlp_model(text)
+
+    def _annotate_entities(self, entities, doc, event_time):
+        """
+            Generates a list of annotations for each entity type in a list of entities.
+
+            Parameters
+            ----------
+            entities: List[spacy.tokens.Span]
+                A list of spacy.tokens.Span objects representing entities
+            doc: spacy.tokens.Doc
+                The spacy doc the entities are derived from
+            event_time: datetime
+                The timestamp that the event occurred on
+
+            Returns
+            -------
+            annotations
+                A dict of lists of Annotation objects, keyed by the annotation type
+        """
+        # Group the extracted entities by entity label
+        sorted_entities = sorted(entities, key=lambda e: e.label_)
+        grouped_entities = groupby(sorted_entities, key=lambda e: e.label_)
+        entities_by_type = {
+            entity_type: list(es) for entity_type, es in grouped_entities
+        }
+
+        # Generate the annotations as appropriate by type
+        annotations_by_entity_type = {}
+        for entity_type, es in entities_by_type.items():
+            entity_type_annotator = self._entity_annotators_by_type[entity_type]
+            annotations_by_entity_type[entity_type] = entity_type_annotator(
+                es, doc, event_time
+            )
+
+        return annotations_by_entity_type
+
     def load(self, transcript, event_metadata):
         sentences_texts = [sentence["text"] for sentence in transcript["sentences"]]
         return (sentences_texts, event_metadata["event_datetime"])
 
     def analyze(self, texts, event_time):
-        return [
-            {"label": "thing", "value": "stuff"},
-            {"label": "person", "value": "George Washington"},
-            {"label": "location", "value": "Seattle"}
-        ]
+        """
+            Generate annotations for a collection of texts related to a single event.
+
+            Parameters
+            ----------
+            sentence_texts: List[str]
+                The list of texts to analyze
+            event_time: datetime
+                The timestamp that the event occurred on
+
+            Returns
+            -------
+            sentence_annotations
+                A list, where each item is a collection of the annotations associated with the
+                corresponding source text.
+        """
+        docs = (self._create_doc(text, self.NLP) for text in texts)
+        doc_annotations_by_entity_type = (
+            self._annotate_entities(doc.ents, doc, event_time) for doc in docs
+        )
+        sentence_annotations = (
+            list(chain(doc_annotations.values()))
+            for doc_annotations in doc_annotations_by_entity_type
+        )
+        return list(sentence_annotations)
+

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -215,7 +215,7 @@ def _span_to_annotation(span, label, value):
 class EntityAnalyzer(NLAnalyzer):
     def __init__(self):
         self.NLP = en_core_web_sm.load()
-        self._entity_annotators_by_type = {
+        self._entity_annotators_by_label = {
             "PERSON": _annotate_person_entities,
             "CARDINAL": _annotate_empty,
             "DATE": _annotate_date_entities,
@@ -264,14 +264,14 @@ class EntityAnalyzer(NLAnalyzer):
         # Group the extracted entities by entity label
         sorted_entities = sorted(entities, key=lambda e: e.label_)
         grouped_entities = groupby(sorted_entities, key=lambda e: e.label_)
-        entities_by_type = {
+        entities_by_label = {
             entity_type: list(es) for entity_type, es in grouped_entities
         }
 
         # Generate the annotations as appropriate by type
         annotations_by_entity_type = {}
-        for entity_type, es in entities_by_type.items():
-            entity_type_annotator = self._entity_annotators_by_type[entity_type]
+        for entity_type, es in entities_by_label.items():
+            entity_type_annotator = self._entity_annotators_by_label[entity_type]
             annotations_by_entity_type[entity_type] = entity_type_annotator(
                 es, doc, event_time
             )

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -2,7 +2,6 @@ from datetime import datetime as dt
 from itertools import chain, groupby
 
 from typing import Any, Callable, List, Union
-from mypy_extensions import TypedDict
 import dateparser
 import en_core_web_sm
 import spacy

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -36,6 +36,7 @@ def _annotate_as_label(label):
             An entity annotator which applies the given label
     """
 
+
     def annotate(entities, doc, event_time):
         """
             Produces annotations consisting of the exact source spacy entity text

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -167,35 +167,6 @@ def _annotate_date_entities(
     return transcribed_dates
 
 
-def _annotate_product_entities(
-    entities: List[spacy.tokens.Span],
-    doc: spacy.tokens.Doc,
-    event_time: datetime
-) -> List[EntityAnnotation]:
-    """
-    Produces annotations of product names, removing commong false positives.
-
-    False positives removed:
-        - "amendment"
-
-    Parameters
-    ----------
-    entities: List[spacy.tokens.Span]
-        A list of spacy.tokens.Span objects representing entities
-    doc: spacy.tokens.Doc
-        The spacy doc the entities are derived from
-    event_time: datetime
-        The timestamp that the event occurred on
-
-    Returns
-    -------
-    annotations: List[EntityAnnotation]
-        A list of product entity annotations
-    """
-    filtered = [e for e in entities if e.text.lower() != "amendment"]
-    return [_span_to_annotation(e, "Entity[Product]", e.text) for e in filtered]
-
-
 def _annotate_money_entities(
     entities: List[spacy.tokens.Span],
     doc: spacy.tokens.Doc,
@@ -250,8 +221,9 @@ def _span_to_annotation(
 
 
 class EntityAnalyzer(NLAnalyzer):
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.NLP = en_core_web_sm.load()
+        self._stopwords_by_label = kwargs.get("stopwords_by_label", {})
         self._entity_annotators_by_label = {
             "PERSON": _annotate_person_entities,
             "CARDINAL": _annotate_empty,
@@ -264,7 +236,7 @@ class EntityAnalyzer(NLAnalyzer):
             "TIME": _annotate_empty,
             "NORP": _annotate_as_label("Entity[NORP]"),
             "QUANTITY": _annotate_empty,
-            "PRODUCT": _annotate_product_entities,
+            "PRODUCT": _annotate_as_label("Entity[Product]"),
             "MONEY": _annotate_money_entities,
             "PERCENT": _annotate_empty,
             "LAW": _annotate_as_label("Entity[Law]"),
@@ -284,7 +256,7 @@ class EntityAnalyzer(NLAnalyzer):
         self,
         entities: List[spacy.tokens.Span],
         doc: spacy.tokens.Doc,
-        event_time: datetime
+        event_time: datetime,
     ) -> Dict[str, List[EntityAnnotation]]:
         """
         Generates a list of annotations for each entity type in a list of entities.
@@ -306,8 +278,34 @@ class EntityAnalyzer(NLAnalyzer):
         # Group the extracted entities by entity label
         sorted_entities = sorted(entities, key=lambda e: e.label_)
         grouped_entities = groupby(sorted_entities, key=lambda e: e.label_)
-        entities_by_label = {
+        raw_entities_by_label = {
             entity_type: list(es) for entity_type, es in grouped_entities
+        }
+
+        def _filter_by_stopwords(
+                entities: List[Spacy.tokens.Span],
+                stopwords: List[str]
+            ) -> List[Spacy.tokens.Span]:
+            """
+            Filter entity spans against a stopword list.
+
+            Parameters
+            ----------
+            entities: List[spacy.tokens.Span]
+                A list of spacy.tokens.Span objects representing entities
+            stopwords: List[str]
+                A list of stopwords
+
+            Returns
+            -------
+            filtered_entities: List[spacy.tokens.Span]
+                The filtered list
+            """
+            return [e for e in entities if e.text.lower() not in stopwords]
+
+        entities_by_label = {
+            entity_type: _filter_by_stopwords(entities, self._stopwords_by_label.get(entity_type, []))
+            for entity_type, es in raw_entities_by_label.items())
         }
 
         # Generate the annotations as appropriate by type
@@ -322,18 +320,21 @@ class EntityAnalyzer(NLAnalyzer):
 
     def load(self, transcript: Dict, event_metadata: Dict) -> Tuple[List[str], datetime]:
         sentences_texts = [sentence["text"] for sentence in transcript["sentences"]]
-        return (sentences_texts, event_metadata["event_datetime"])
+        return {
+            "texts": sentences_texts,
+            "event_time": event_metadata["event_datetime"]
+        }
 
-    def analyze(self, texts: List[str], event_time: datetime) -> List[List[EntityAnnotation]]:
+    def analyze(self, load_output: Dict) -> List[List[EntityAnnotation]]:
         """
         Generate annotations for a collection of texts related to a single event.
 
         Parameters
         ----------
-        sentence_texts: List[str]
-            The list of texts to analyze
-        event_time: datetime
-            The timestamp that the event occurred on
+        load_output: Dict
+            Output from the load method, including the following keys:
+            texts: List[str]
+            event_time: datetime
 
         Returns
         -------

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -6,8 +6,18 @@ import dateparser
 import en_core_web_sm
 import spacy
 from spacy import displacy
+from spacy.cli import download
 
 from .nl_analyzer import NLAnalyzer
+
+
+MODEL_NAME = "en_core_web_sm"
+
+try:
+    spacy.load(MODEL_NAME)
+except OSError:
+    download(MODEL_NAME)
+    spacy.load(MODEL_NAME)
 
 
 def _annotate_as_label(label):

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -7,7 +7,7 @@ import en_core_web_sm
 import spacy
 from spacy import displacy
 
-from nl_analyzer import NLAnalyzer
+from .nl_analyzer import NLAnalyzer
 
 
 def _annotate_as_label(label):

--- a/cdptools/natural_language_analyzers/entity_analyzer.py
+++ b/cdptools/natural_language_analyzers/entity_analyzer.py
@@ -305,7 +305,7 @@ class EntityAnalyzer(NLAnalyzer):
 
         entities_by_label = {
             entity_type: _filter_by_stopwords(entities, self._stopwords_by_label.get(entity_type, []))
-            for entity_type, es in raw_entities_by_label.items())
+            for entity_type, es in raw_entities_by_label.items()
         }
 
         # Generate the annotations as appropriate by type

--- a/cdptools/natural_language_analyzers/nl_analyzer.py
+++ b/cdptools/natural_language_analyzers/nl_analyzer.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from abc import ABC, abstractmethod
 
 

--- a/cdptools/natural_language_analyzers/word_count_nl_analyzer.py
+++ b/cdptools/natural_language_analyzers/word_count_nl_analyzer.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import re
 
 from .nl_analyzer import NLAnalyzer

--- a/cdptools/pipelines/event_nl_analyze_pipeline.py
+++ b/cdptools/pipelines/event_nl_analyze_pipeline.py
@@ -101,8 +101,11 @@ class EventNLAnalyzePipeline(Pipeline):
                 exe.map(uploader, entities)
 
     def process_event(self, event: Dict) -> str:
+        print("processing event", event["metadata"]["metadata"]["event_id"])
         # Other tasks will go here
-        self.task_extract_and_upload_entities(event, self.config)
+        self.task_extract_and_upload_entities(event)
+
+        print("completed event", event["metadata"]["metadata"]["event_id"])
 
         # Update progress
         log.info("Completed event: {} ({}) ".format(
@@ -137,7 +140,7 @@ class EventNLAnalyzePipeline(Pipeline):
 
                 events = []
                 for metadata in event_metadata_list:
-                    transcript_path = event_corpus_map[metadata["event_id"]]
+                    transcript_path = event_corpus_map[metadata["metadata"]["event_id"]]
                     transcript = transcript_tools.load_transcript(transcript_path, join_text=True, sep=" ")
 
                     events.append({"metadata": metadata, "transcript": transcript})
@@ -146,7 +149,7 @@ class EventNLAnalyzePipeline(Pipeline):
             # Since NLAnalyzer tasks are likely CPU intensive, use ProcessPoolExecutor
             # which can only accept pickleable arguments
             with ProcessPoolExecutor(self.n_workers) as exe:
-                exe.map(self.process_event, events)
+                list(exe.map(self.process_event, events))
 
         log.info("Completed event processing.")
         log.info("=" * 80)

--- a/cdptools/pipelines/event_nl_analyze_pipeline.py
+++ b/cdptools/pipelines/event_nl_analyze_pipeline.py
@@ -71,9 +71,9 @@ class EventNLAnalyzePipeline(Pipeline):
         ):
             entity_analyzer = load_custom_object.load_custom_object_from_config("entity_analyzer", self.config)
 
-            input = entity_analyzer.load(event["transcript"], event["metadata"])
+            analyzer_input = entity_analyzer.load(event["transcript"], event["metadata"])
 
-            entities = entity_analyzer.analyze(*input)
+            entities = entity_analyzer.analyze(analyzer_input)
 
             for entity in entities:
                 database.get_or_upload_event_entity(

--- a/configs/seattle-event-nl-analyze-pipeline.json
+++ b/configs/seattle-event-nl-analyze-pipeline.json
@@ -17,6 +17,13 @@
     },
     "entity_analyzer": {
         "module_path": "cdptools.natural_language_analyzers.entity_analyzer",
-        "object_name": "EntityAnalyzer"
+        "object_name": "EntityAnalyzer",
+        "object_kwargs": {
+            "stopwords_by_label": {
+                "PRODUCT": [
+                    "amendment"
+                ]
+            }
+        }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ requirements = [
     "schedule==0.6.0",
     "spacy==2.1.8",
     "tika==1.19",
-    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz",
 ]
 
 local_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ interactive_requirements = [
 requirements = [
     "beautifulsoup4==4.8.0",
     "dateparser==0.7.1",
-    "en-core-web-sm==2.1.0",
     "ffmpeg-python==0.2.0",
     "fuzzywuzzy==0.17.0",
     "nltk==3.4.4",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ requirements = [
     "requests==2.22.0",
     "schedule==0.6.0",
     "spacy==2.1.8",
-    "tika==1.19"
+    "tika==1.19",
+    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz",
 ]
 
 local_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ interactive_requirements = [
 
 requirements = [
     "beautifulsoup4==4.8.0",
+    "dateparser==0.7.1",
+    "en-core-web-sm==2.1.0",
     "ffmpeg-python==0.2.0",
     "fuzzywuzzy==0.17.0",
     "nltk==3.4.4",
@@ -50,6 +52,7 @@ requirements = [
     "python-Levenshtein==0.12.0",
     "requests==2.22.0",
     "schedule==0.6.0",
+    "spacy==2.1.8",
     "tika==1.19"
 ]
 


### PR DESCRIPTION
Adds an entity annotator class, designed to produce block-level annotations for a document based off of Spacy's entity classes.

![Screen Shot 2019-08-16 at 9 04 39 AM](https://user-images.githubusercontent.com/766944/63181462-e96abf00-c004-11e9-9c66-2fb0537d6765.png)

> For each input sentence, produces a list of annotations for that sentence.

## Overview

1. Add `spacy` and `dateparser` dependencies to `Setup.py`
2. Implement a new `EntityAnalzyer` class, extending `NLAnalyzer`
2. Adjust `natural_language_analyzer` module `__init__.py` to include the new class

## EntityAnalyzer

When imported, `entity_analyzer.py` attempts to load the `en_core_web_sm` Spacy model. If it fails, it downloads it at runtime. This follows the pattern established in `./indexers/indexer.py`.

The `load(..)` method of the  `EntityAnalzyer` class expects to be provided the transcript dict and a dict representing the metadata for the event being analyzed - in particular it requires the `event_datetime` key of the event metadata dict to be populated with a `datetime` value. This datetime value is used as the basis for parsing relative dates within the document. The method then extracts the sentence level text values from the transcript.

The `analyze(..)` method iterates over the sentence texts, passing each to Spacy's NLP model to perform entity extraction. The method then produces annotations for each sentence based on the extracted entities. The nature of the annotations produced depends on the entity type. On `__init__(..)`, the class defines an `_entity_annotators_by_label` dict, whose keys are Spacy entity type labels and whose value is a function transforming a collection of entities of that type into a collection of annotations.

## Entity Tag-based Annotations

For most entity types, we either produce no annotations for that type (e.g. CARDINAL entities are simply too noisy) or produce annotations that directly map the text the entity was derived from (e.g. LOC entities, representing locations).

A custom annotator can be given for each entity type. For example, Spacy often extracts the word `amendment` as a PRODUCT entity, which is very noisy. The entity annotator for the PRODUCT tag filters these out.

A more useful entity tag annotator is the DATE annotator. Spacy extract absolute (e.g. "August 23rd 2019", imprecise (e.g. "August 23rd" - what year?), and relative (e.g. "Yesterday") dates. Using the dateparse library and the date that the event occurred as a baseline, all of these entities are resolved to an absolute datetime, which is produced as the value of the annotation.

## Follow-up Work

As a potential follow-up task and a relatively easy area for language-minded people to contribute, the entity annotators can be worked on in relative isolation from the rest of the system. By reviewing common false positives, contributors could add to a set of stopword lists for each entity type and help improve the system with very minor code changes.

A more substantial task for someone interested in language analysis might be to implement a custom annotator for MONEY entities. When Spacy extracts monetary entities we're left without any context about what that monetary value references - e.g. whether it's a budgetary item, an expense, tax revenues, etc. It may be possible to extract some context by further analyzing the syntactic structure of the sentence, which is already available as part of Spacy's analysis.
